### PR TITLE
Feat: Autorización aplicada en los endpoints de Mascota

### DIFF
--- a/backend/src/mascota/condicion.model.ts
+++ b/backend/src/mascota/condicion.model.ts
@@ -18,11 +18,11 @@ export class Condicion extends Model<Condicion> {
     type: DataType.STRING,
     allowNull: false,
   })
-  nombre: string;
+  declare nombre: string;
 
   @Column({
     type: DataType.STRING,
     allowNull: true,
   })
-  descripcion?: string;
+  declare descripcion?: string;
 }

--- a/backend/src/mascota/dto/create-mascota.dto.ts
+++ b/backend/src/mascota/dto/create-mascota.dto.ts
@@ -59,8 +59,4 @@ export class CreateMascotaDto {
   @IsInt()
   @IsNotEmpty()
   condicion_id: number;
-
-  @IsInt()
-  @IsNotEmpty()
-  usuario_id: number;
 }

--- a/backend/src/mascota/especie.model.ts
+++ b/backend/src/mascota/especie.model.ts
@@ -18,5 +18,5 @@ export class Especie extends Model<Especie> {
     type: DataType.STRING,
     allowNull: false,
   })
-  nombre: string;
+  declare nombre: string;
 }

--- a/backend/src/mascota/mascota.controller.ts
+++ b/backend/src/mascota/mascota.controller.ts
@@ -7,43 +7,60 @@ import {
   Body,
   Post,
   Patch,
-  Request,
+  Req,
 } from '@nestjs/common';
 import { MascotaService } from './mascota.service';
 import { Mascota } from './mascota.model';
 import { CreateMascotaDto } from './dto/create-mascota.dto';
 import { UpdateMascotaDto } from './dto/update-mascota.dto';
 import { AuthenticatedRequest } from 'src/auth/jwt-playload.interface';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { Role } from 'src/auth/roles.enum';
 
-@Controller('user/:id/mascotas')
+@Controller('usuarios/:id/mascotas')
 export class MascotasController {
   constructor(private readonly mascotaService: MascotaService) {}
 
   @Get()
-  findAll(@Request() req: AuthenticatedRequest): Promise<Mascota[]> {
+  @Roles(Role.ADMIN, Role.PUBLICADOR)
+  findAll(@Req() req: AuthenticatedRequest): Promise<Mascota[]> {
     return this.mascotaService.findAll(req.user);
   }
 
-  @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Mascota> {
-    return this.mascotaService.findOne(id);
+  @Post()
+  @Roles(Role.PUBLICADOR)
+  create(
+    @Body() createMascotaDto: CreateMascotaDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Mascota> {
+    return this.mascotaService.create(createMascotaDto, req.user);
   }
 
-  @Post()
-  create(@Body() createMascotaDto: CreateMascotaDto): Promise<Mascota> {
-    return this.mascotaService.create(createMascotaDto);
+  @Get(':id')
+  @Roles(Role.ADMIN, Role.PUBLICADOR)
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Mascota> {
+    return this.mascotaService.findOne(id, req.user);
   }
 
   @Patch(':id')
+  @Roles(Role.ADMIN, Role.PUBLICADOR)
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateMascotaDto: UpdateMascotaDto,
+    @Req() req: AuthenticatedRequest,
   ): Promise<Mascota> {
-    return this.mascotaService.update(id, updateMascotaDto);
+    return this.mascotaService.update(id, updateMascotaDto, req.user);
   }
 
   @Delete(':id')
-  remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    return this.mascotaService.remove(id);
+  @Roles(Role.ADMIN, Role.PUBLICADOR)
+  remove(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<void> {
+    return this.mascotaService.remove(id, req.user);
   }
 }

--- a/backend/src/mascota/mascota.model.ts
+++ b/backend/src/mascota/mascota.model.ts
@@ -26,50 +26,50 @@ export class Mascota extends Model<Mascota, Partial<Mascota>> {
     type: DataType.STRING(100),
     allowNull: false,
   })
-  nombre: string;
+  declare nombre: string;
 
   @Column({
     type: DataType.STRING(100),
     allowNull: true,
   })
-  raza?: string;
+  declare raza?: string;
 
   @Column({
     type: DataType.ENUM('Macho', 'Hembra'),
     allowNull: false,
   })
-  sexo: string;
+  declare sexo: string;
 
   @Column({
     type: DataType.INTEGER,
     allowNull: true,
   })
-  edad?: number;
+  declare edad?: number;
 
   @Column({
     type: DataType.BOOLEAN,
     allowNull: false,
   })
-  vacunado: boolean;
+  declare vacunado: boolean;
 
   @Column({
     type: DataType.ENUM('Chico', 'Mediano', 'Grande'),
     allowNull: false,
   })
-  tamanio: string;
+  declare tamanio: string;
 
   @Column({
     type: DataType.JSON,
     allowNull: false,
   })
-  fotos_url: string[];
+  declare fotos_url: string[];
 
   @ForeignKey(() => Especie)
   @Column({
     type: DataType.INTEGER,
     allowNull: false,
   })
-  especie_id: number;
+  declare especie_id: number;
 
   @BelongsTo(() => Especie)
   especie: Especie;
@@ -79,7 +79,7 @@ export class Mascota extends Model<Mascota, Partial<Mascota>> {
     type: DataType.INTEGER,
     allowNull: false,
   })
-  condicion_id: number;
+  declare condicion_id: number;
 
   @BelongsTo(() => Condicion)
   condicion: Condicion;
@@ -89,7 +89,7 @@ export class Mascota extends Model<Mascota, Partial<Mascota>> {
     type: DataType.INTEGER,
     allowNull: false,
   })
-  usuario_id: number;
+  declare usuario_id: number;
 
   @BelongsTo(() => User, {
     foreignKey: 'usuario_id',

--- a/backend/src/mascota/mascota.module.ts
+++ b/backend/src/mascota/mascota.module.ts
@@ -6,9 +6,13 @@ import { MascotasController } from './mascota.controller';
 import { Especie } from './especie.model';
 import { Condicion } from './condicion.model';
 import { User } from 'src/usuario/usuario.model';
+import { AccesoModule } from 'src/acceso/acceso.module';
 
 @Module({
-  imports: [SequelizeModule.forFeature([Mascota, Especie, Condicion, User])],
+  imports: [
+    SequelizeModule.forFeature([Mascota, Especie, Condicion, User]),
+    AccesoModule,
+  ],
   providers: [MascotaService],
   controllers: [MascotasController],
 })

--- a/backend/src/usuario/usuario.controller.ts
+++ b/backend/src/usuario/usuario.controller.ts
@@ -32,7 +32,6 @@ export class UsersController {
   @Get('perfil')
   @Roles(Role.ADMIN, Role.PUBLICADOR)
   getPerfil(@Req() req: AuthenticatedRequest) {
-    console.log('GET /perfil ejecutado');
     const usuario = req.user;
     return this.usersService.findOne(usuario.sub);
   }


### PR DESCRIPTION
En los endpoints de Mascota ahora se valida el usuario_id del usuario logueado para permitir el acceso, la actualización o la eliminación de la mascota y en el create el usuario_id de la mascota ya no se debe enviar en el body del request, se setea con el usuario_id del usuario logueado (el usuario_id del token)